### PR TITLE
Clarify default password in seeder

### DIFF
--- a/database/seeds/PermissionsDemoSeeder.php
+++ b/database/seeds/PermissionsDemoSeeder.php
@@ -32,11 +32,10 @@ class PermissionsDemoSeeder extends Seeder
         $role2->givePermissionTo('publish articles');
         $role2->givePermissionTo('unpublish articles');
 
-        // create a demo user
+        // create a demo user - see UserFactory for default password
         $user = Factory(App\User::class)->create([
             'name' => 'Example User',
             'email' => 'test@example.com',
-            'password' => bcrypt('secret'),
         ]);
         $user->assignRole($role1);
     }

--- a/database/seeds/PermissionsDemoSeeder.php
+++ b/database/seeds/PermissionsDemoSeeder.php
@@ -36,7 +36,7 @@ class PermissionsDemoSeeder extends Seeder
         $user = Factory(App\User::class)->create([
             'name' => 'Example User',
             'email' => 'test@example.com',
-            // factory default password is 'secret'
+            'password' => bcrypt('secret'),
         ]);
         $user->assignRole($role1);
     }


### PR DESCRIPTION
Hi. 
Now, November 2019, with LR6, sqlite for database, almost for me  `secret` not work how password.

I have needed to specify the password