### PR TITLE
Fix reference to default password. Actually 'password', not 'secret'.

### DIFF
--- a/database/seeds/PermissionsDemoSeeder.php
+++ b/database/seeds/PermissionsDemoSeeder.php
@@ -36,7 +36,7 @@ class PermissionsDemoSeeder extends Seeder
         $user = Factory(App\User::class)->create([
             'name' => 'Example User',
             'email' => 'test@example.com',
-            // factory default password is 'secret'
+            // factory default password is 'password'
         ]);
         $user->assignRole($role1);
     }


### PR DESCRIPTION
The comment describing the default password for the test/example user created by the seeder is incorrect.