### PR TITLE
Fixed permission names and made interface more user friendly

### DIFF
--- a/app/Http/Controllers/ExamplesController.php
+++ b/app/Http/Controllers/ExamplesController.php
@@ -9,12 +9,10 @@ class ExamplesController extends Controller
 {
     public function show_my_roles()
     {
-//        $user = auth()->user();
-//        or
-        $user = User::first();
+        $user = auth()->user();
         $roles = $user->getRoleNames();
 
-        return var_export($roles, true);
+        return dd($roles);
 
 // output:
 /**

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -63,7 +63,7 @@ class Kernel extends HttpKernel
         'signed' => \App\Http\Middleware\ValidateSignature::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
-        'role' => \Spatie\Permission\Middlewares\RoleMiddleware::class,
-        'permission' => \Spatie\Permission\Middlewares\PermissionMiddleware::class,
+        'role' => \Spatie\Permission\Middleware\RoleMiddleware::class,
+        'permission' => \Spatie\Permission\Middleware\PermissionMiddleware::class,
     ];
 }

--- a/app/Policies/PostPolicy.php
+++ b/app/Policies/PostPolicy.php
@@ -60,6 +60,15 @@ class PostPolicy
      */
     public function update(User $user, Post $post)
     {
+        // THIS WILL WORK
+        // The parameter here MUST match the permissions in your database.
+        // 'edit articles' is not a permission in our PermissionsDemoSeeder
+        // So this will actually check the policy and return true is user has this permission
+        // Note Order. If it matches here we return true. If it doesn't we proceed to next check
+        if ($user->can('edit articles')) {
+            return true;
+        }
+
         // THIS WILL NOT WORK
         // The parameter here MUST match the permissions in your database.
         // 'edit own posts' is not a permission in our PermissionsDemoSeeder
@@ -67,13 +76,6 @@ class PostPolicy
         // To fix this add "edit own posts" permission and assign it to a role or user
         if ($user->can('edit own posts')) {
             return $user->id == $post->user_id;
-        }
-        // THIS WILL WORK
-        // The parameter here MUST match the permissions in your database.
-        // 'edit articles' is not a permission in our PermissionsDemoSeeder
-        // So this will actually check the policy and return true is user has this permission
-        if ($user->can('edit articles')) {
-            return true;
         }
     }
 
@@ -86,6 +88,7 @@ class PostPolicy
      */
     public function delete(User $user, Post $post)
     {
+
         if ($user->can('delete own articles')) {
             return $user->id == $post->user_id;
         }

--- a/app/Policies/PostPolicy.php
+++ b/app/Policies/PostPolicy.php
@@ -34,16 +34,6 @@ class PostPolicy
             return true;
         }
 
-        // visitors cannot view unpublished items
-        if ($user === null) {
-            return false;
-        }
-
-        // admin overrides published status
-        if ($user->can('view unpublished posts')) {
-            return true;
-        }
-
         // authors can view their own unpublished posts
         return $user->id == $post->user_id;
     }
@@ -56,7 +46,7 @@ class PostPolicy
      */
     public function create(User $user)
     {
-        if ($user->can('create posts')) {
+        if ($user->can('publish articles')) {
             return true;
         }
     }
@@ -70,11 +60,19 @@ class PostPolicy
      */
     public function update(User $user, Post $post)
     {
+        // THIS WILL NOT WORK
+        // The parameter here MUST match the permissions in your database.
+        // 'edit own posts' is not a permission in our PermissionsDemoSeeder
+        // You won't get any run time errors but this will always return false
+        // To fix this add "edit own posts" permission and assign it to a role or user
         if ($user->can('edit own posts')) {
             return $user->id == $post->user_id;
         }
-
-        if ($user->can('edit all posts')) {
+        // THIS WILL WORK
+        // The parameter here MUST match the permissions in your database.
+        // 'edit articles' is not a permission in our PermissionsDemoSeeder
+        // So this will actually check the policy and return true is user has this permission
+        if ($user->can('edit articles')) {
             return true;
         }
     }
@@ -88,11 +86,11 @@ class PostPolicy
      */
     public function delete(User $user, Post $post)
     {
-        if ($user->can('delete own posts')) {
+        if ($user->can('delete own articles')) {
             return $user->id == $post->user_id;
         }
 
-        if ($user->can('delete any post')) {
+        if ($user->can('delete articles')) {
             return true;
         }
     }

--- a/database/seeders/PermissionsDemoSeeder.php
+++ b/database/seeders/PermissionsDemoSeeder.php
@@ -24,6 +24,9 @@ class PermissionsDemoSeeder extends Seeder
         Permission::create(['name' => 'delete articles']);
         Permission::create(['name' => 'publish articles']);
         Permission::create(['name' => 'unpublish articles']);
+        Permission::create(['name' => 'delete own articles']);
+        // For Super Admin
+        Permission::create(['name' => 'assign roles']);
 
         // create roles and assign existing permissions
         $role1 = Role::create(['name' => 'Writer']);
@@ -33,6 +36,7 @@ class PermissionsDemoSeeder extends Seeder
         $role2 = Role::create(['name' => 'Admin']);
         $role2->givePermissionTo('publish articles');
         $role2->givePermissionTo('unpublish articles');
+        $role2->givePermissionTo('delete own articles');
 
         // create a demo user
         $user = \App\Models\User::factory()->create([
@@ -43,7 +47,6 @@ class PermissionsDemoSeeder extends Seeder
 
 
         // super admin
-        Permission::create(['name' => 'assign roles']);
         $role3 = Role::create(['name' => 'Super-Admin']);
         $role3->givePermissionTo('assign roles');
         $admin = \App\Models\User::factory()->create([

--- a/database/seeders/PermissionsDemoSeeder.php
+++ b/database/seeders/PermissionsDemoSeeder.php
@@ -54,5 +54,25 @@ class PermissionsDemoSeeder extends Seeder
             'email' => 'admin@example.com',
         ]);
         $admin->assignRole('Super-Admin');
+
+        # Assign some random posts that are published
+        for($i = 0; $i < 15; $i++) {
+            $posts = \App\Models\Post::factory()->create([
+                                                              'title' => fake()->sentence(),
+                                                              'user_id' => random_int(1, 2),
+                                                              'body' => fake()->realText(),
+                                                              'published' => '1',
+                                                          ]);
+        }
+
+        # Assign some random posts that are unpublished
+        for($i = 0; $i < 15; $i++) {
+            $posts = \App\Models\Post::factory()->create([
+                                                             'title' => fake()->sentence(),
+                                                             'user_id' => random_int(1, 2),
+                                                             'body' => fake()->realText(),
+                                                             'published' => '',
+                                                         ]);
+        }
     }
 }

--- a/resources/views/permissions-demo.blade.php
+++ b/resources/views/permissions-demo.blade.php
@@ -9,3 +9,11 @@
 @else
   <p>Sorry, you may NOT edit articles.</p>
 @endcan
+
+  <div>
+      <a href="{{route('showAssignedRoles')}}">Assign Permissions Page</a>
+  </div>
+    <div>
+        <a href="{{route('show')}}">My Roles</a>
+        <a href="{{route('post.index')}}">View Posts</a>
+    </div>

--- a/resources/views/permissions-demo.blade.php
+++ b/resources/views/permissions-demo.blade.php
@@ -10,10 +10,11 @@
   <p>Sorry, you may NOT edit articles.</p>
 @endcan
 
+
   <div>
-      <a href="{{route('showAssignedRoles')}}">Assign Permissions Page</a>
+      <ul>
+          <li><a href="{{route('showAssignedRoles')}}">Assign Permissions Page</a></li>
+          <li> <a href="{{route('show')}}">View My Roles</a></li>
+          <li><a href="{{route('post.index')}}">View Posts</a></li>
+      </ul>
   </div>
-    <div>
-        <a href="{{route('show')}}">My Roles</a>
-        <a href="{{route('post.index')}}">View Posts</a>
-    </div>

--- a/resources/views/posts/edit.blade.php
+++ b/resources/views/posts/edit.blade.php
@@ -1,2 +1,4 @@
 This would be the edit form for the post:
 {{ $post->title }}
+
+<p>If you didn't have the edit articles PERMISSION that the "Writer" ROLE provides you would get a 403 error instead of this page. Try that out by logging in as admin account which won't have this permission and will return a 403 error.</p>

--- a/resources/views/posts/index.blade.php
+++ b/resources/views/posts/index.blade.php
@@ -1,3 +1,3 @@
 @foreach($posts as $p)
-  <p>{{ $p->id }}. {{ $p->title }}</p>
+  <p>{{ $p->id }}. <a href="{{route('post.show', ['post' => $p->id])}}"> {{ $p->title }}</a></p>
 @endforeach

--- a/resources/views/posts/index.blade.php
+++ b/resources/views/posts/index.blade.php
@@ -1,3 +1,13 @@
+@can('edit articles')
+    <p>You have permission to [edit articles]. Clicking Edit Post below will return a edit page</p>
+@else
+    <p>You do NOT have permission to edit articles. Clicking edit below will return a 403 Error</p>
+@endcan
+
 @foreach($posts as $p)
-  <p>{{ $p->id }}. <a href="{{route('post.show', ['post' => $p->id])}}"> {{ $p->title }}</a></p>
+    <p>{{ $p->id }}. <a href="{{route('post.show', ['post' => $p->id])}}"> {{ $p->title }}</a> (<a href="{{route('post.edit', ['post' => $p->id])}}">Edit Post</a>)</p>
 @endforeach
+
+<p>
+    <a href="{{route('home')}}" class="">Back to Demo Home Page</a>
+</p>

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -1,1 +1,10 @@
-{{ $post->title }}
+<p>Title: <strong>{{ $post->title }}</strong></p>
+<p>{{ $post->body }}</p>
+
+@can('edit articles')
+    <p><a href="{{route('post.edit', ['post' => $p->id])}}">Edit Post</a></p>
+@endcan
+
+<p>
+    <a href="{{route('home')}}" class="">Back to Demo Home Page</a>
+</p>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -16,7 +16,7 @@
         </style>
     </head>
     <body class="antialiased">
-        <div class="relative sm:flex sm:justify-center sm:items-center min-h-screen bg-dots-darker bg-center bg-gray-100 dark:bg-dots-lighter dark:bg-gray-900 selection:bg-red-500 selection:text-white">
+        <div class="relative sm:flex sm:justify-center sm:items-center min-h-screen bg-dots-darker bg-center bg-gray-100 dark:bg-dots-lighter dark:bg-gray-900 selection:bg-red-500 selection:text-white dark:text-white">
             @if (Route::has('login'))
                 <div class="sm:fixed sm:top-0 sm:right-0 p-6 text-right">
                     @auth
@@ -41,10 +41,39 @@
                 <div class="mt-16">
                     <div class="grid grid-cols-1 md:grid-cols-2 gap-6 lg:gap-8">
 
-                    @include('permissions-demo')
+                        @hasrole('writer')
+                        <p>You have been assigned the [writer] role.</p>
+                        @else
+                            <p>You do NOT have the writer role.</p>
+                            @endhasrole
+
+                            @can('edit articles')
+                                <p>You have permission to [edit articles].</p>
+                            @else
+                                <p>Sorry, you may NOT edit articles.</p>
+                            @endcan
 
                     </div>
+
+
                 </div>
+                <div>
+                    <h1 class="text-xl mt-6 font-bold">Example Accounts:</h1>
+                    <div>
+                        <h2 class="text-lg mt-6 mb-4 font-bold">Admin Account</h2>
+                        <p>User: admin@example.com</p>
+                        <p>Password: password</p>
+                    </div>
+                    <div class="blockquote">
+                        <h2 class="text-lg mt-6 mb-4 font-bold">Normal Account with Writer Role</h2>
+                        <p>User: test@example.com</p>
+                        <p>Password: password</p>
+                    </div>
+
+                </div>
+                <p class="text-xl text-center btn btn-md btn-danger mt-6">
+                    <a href="{{route('home')}}" class="">View Demo</a>
+                </p>
 
                 <div class="flex justify-center mt-16 px-0 sm:items-center sm:justify-between">
                     <div class="text-center text-sm text-gray-500 dark:text-gray-400 sm:text-left">


### PR DESCRIPTION
- The permissions in PostPolicy did not match the name of permissions created by seeder so none of the policy checks ever worked causing confusion for users trying to learn how this package works.  Fixed that in the edit case, also left a wrong case with comments explaining the issue and how the permission names must match what you have in your database for those that might be using the default Policy creator from Laravel. Removed some of the policies that were not needed
- Improved the interface to give you login info on the welcome page and link to demo dashboard
- Added all the routes to demo dashboard as links
- Added posts to the DB seeder so could test permissions on the posts page.
- Documented the permissions you do have and don't have on the blade views to make things easier to understand for new users to the spatie-permissions package.